### PR TITLE
Security patch.

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -14,7 +14,7 @@ session_start();
 if(isset($_POST['submit'])) {
 $user=$_POST['user'];
 $pass=$_POST['pass'];
-if($user == "rez" && $pass == "0c45dg4ffg123vc1b23456d74dsdfsdf") {
+if($user === "rez" && $pass === "0c45dg4ffg123vc1b23456d74dsdfsdf") {
     // print_r($_POST);
     $_SESSION['login']=true;
     header("Location: index.php");


### PR DESCRIPTION
When comparing usernames or passwords during a login process, it should always be done with strict comparison, and never loose comparison.

```PHP
<?php
$Example = "0asdasd";

echo $Example == "0" ? "True" : "False";
// Will echo "True".

echo $Example === "0" ? "True" : "False";
// Will echo "False".
```

Due to PHP's "type juggling" (or "type coercion"), it's sometimes possible for users to enter an incorrect value (username or password), but have the system still accept it as the correct value, in the case that the entered value and the actual correct value are equivalent after being "juggled" or "coerced".

This potential security issue can be resolved by using strict comparison, since this juggling/coercion doesn't occur when using strict comparison.
